### PR TITLE
fix: resolve invisible popup in some IDEs (#6)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,8 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("252.*")
+        // Remove the limitation on the maximum supported build to avoid IDEs installing the outdated 2.0.8 release
+        untilBuild.set("")
         changeNotes.set("""
             version 4.0.1:
             <ul>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.9.21"
-    id("org.jetbrains.intellij") version "1.16.1"
+    id("org.jetbrains.kotlin.jvm") version "1.9.25"
+    id("org.jetbrains.intellij") version "1.17.3"
 }
 
 group = "com.mnr.intellij.plugin"
-version = "4.0.0"
+version = "4.0.1"
 
 repositories {
     mavenCentral()
@@ -32,8 +32,13 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("241.*")
+        untilBuild.set("252.*")
         changeNotes.set("""
+            version 4.0.1:
+            <ul>
+                <li>Fix issue with pop-up menu not showing in some contexts</li>
+            </ul>
+            
             version 4.0.0:
             <ul>
                 <li>Using new Intellij <a href="https://plugins.jetbrains.com/docs/intellij/general-threading-rules.html">threading</a></li>

--- a/src/main/java/com/mnr/intellij/plugin/base64helper/MainActionHandler.java
+++ b/src/main/java/com/mnr/intellij/plugin/base64helper/MainActionHandler.java
@@ -213,10 +213,6 @@ public class MainActionHandler extends AnAction {
     }
 
     private String getEditorSelectedText(Editor editor) {
-        final String[] selectedText = new String[1];
-        ReadAction.run(() -> {
-            selectedText[0] = editor.getSelectionModel().getSelectedText();
-        });
-        return selectedText[0];
+        return ReadAction.compute(() -> editor.getSelectionModel().getSelectedText());
     }
 }

--- a/src/main/java/com/mnr/intellij/plugin/base64helper/MainActionHandler.java
+++ b/src/main/java/com/mnr/intellij/plugin/base64helper/MainActionHandler.java
@@ -213,6 +213,10 @@ public class MainActionHandler extends AnAction {
     }
 
     private String getEditorSelectedText(Editor editor) {
-        return ReadAction.compute(() -> editor.getSelectionModel().getSelectedText());
+        final String[] selectedText = new String[1];
+        ReadAction.run(() -> {
+            selectedText[0] = editor.getSelectionModel().getSelectedText();
+        });
+        return selectedText[0];
     }
 }


### PR DESCRIPTION
# Summary
This PR updates the plugin metadata to remove the until-build restriction.
Previously, the plugin was limited to `241.*`, which caused newer IDEs (e.g. 2024.x, 2025.x) to treat version `2.0.3` as the latest available release.

## Changes:
- Removed until-build property from plugin.xml / patchPluginXml task.
- Ensures the plugin remains installable on upcoming IDE versions without reverting to outdated releases.

## Motivation:
- Prevents users of newer IDEs from being stuck on `2.0.3` which doesn't work in all new IDEs
- Keeps the plugin future-compatible until a real incompatibility arises.
- Closes #6 